### PR TITLE
Add support for including `aspectRatio` in Bluesky post records

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Install the extra Python libraries needed for the project.  Enter the following 
 ```bash
 sudo apt install python3-tweepy
 sudo pip install atproto --break-system-packages
+sudo pip install pillow --break-system-packages
 ```
 
 ## Install the Daphne Flap Project

--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
-from atproto import Client
+from PIL import Image
+from atproto import Client, models
 from subprocess import call
 from datetime import datetime
 from grammar import Grammar
@@ -70,16 +71,25 @@ def goGoPaparazzo():
 
     if settings.post_bluesky == True:
         # post to bluesky
+        from PIL import Image
+        from atproto import models
+    
         client = Client(base_url="https://bsky.social")
         client.login(settings.bluesky_user, settings.bluesky_pass)
 
         with open("capture.jpg", "rb") as c:
             img_data = c.read()
-
+    
+        with Image.open("capture.jpg") as im:
+            width, height = im.size
+    
+        aspect_ratio = models.AppBskyEmbedDefs.AspectRatio(height=height, width=width)
+    
         client.send_image(
             text = message,
             image = img_data,
-            image_alt = "Daphne the cat using her internet connected catflap."
+            image_alt = "Daphne the cat using her internet connected catflap.",
+            image_aspect_ratio = aspect_ratio
         )
 
         print("Posted to Bluesky.")

--- a/main.py
+++ b/main.py
@@ -79,7 +79,7 @@ def goGoPaparazzo():
 
         with open("capture.jpg", "rb") as c:
             img_data = c.read()
-    
+
         with Image.open("capture.jpg") as im:
             width, height = im.size
     


### PR DESCRIPTION
## Summary

This PR adds support for the `aspectRatio` field in Bluesky posts to prevent images from being displayed with unwanted borders.

## Problem

Currently, images posted to [Daphne's catflap's Bluesky account](https://bsky.app/profile/daphnethecat.com) have borders at the top and bottom:

<img width="603" height="811" alt="IMG_7075" src="https://github.com/user-attachments/assets/a688db70-ff23-4f52-a181-9f9dadb8f4a7" />


This is how the Bluesky app [now displays images](https://github.com/bluesky-social/social-app/pull/6828) that don't have an [`aspectRatio`](https://docs.bsky.app/docs/advanced-guides/posts#images-embeds) defined in the post record.

## Solution

The `atproto` library already supports including the aspect ratio via the `image_aspect_ratio` parameter in [`send_image`](https://github.com/MarshalX/atproto/blob/main/examples/send_image.py).

This PR:
- Adds [Pillow](https://pillow.readthedocs.io/en/stable/) as a dependency to read image dimensions
- Modifies `main.py` to extract the width and height from captured images
- Passes the aspect ratio to `client.send_image()` using `models.AppBskyEmbedDefs.AspectRatio`

> [!WARNING]
> I'm not a coder, so this was [vibe-coded by Claude](https://claude.ai/share/9f93a107-930c-426c-80bd-d2b6b56482b9) and **I have not tested it**.