### PR TITLE
Moves to using gpiozero package over rpi.gpio

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,8 @@ pip install -r requirements.txt
 
 (this may take some time to complete).
 
+You may see warnings about packages that can't be uninstalled because they are outside the virtual environment, and errors about dependency conflicts with unrelated system packages (`pyopenssl`, `types-flask-migrate`). These can be ignored — as long as the output ends with `Successfully installed`, everything is fine.
+
 ## Test the Camera with the Project Script
 
 Enter the following command at the terminal:

--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ then
 sudo apt install gir1.2-peas-1.0
 ```
 
+then
+
+```bash
+sudo apt install python3-lgpio
+```
+
 Connect the camera to one of the USB ports on the Pi.
 
 Now test the camera.  Enter the command:
@@ -140,7 +146,7 @@ To ensure that the Python libraries we need to install run in a clean environmen
 Enter the following commands:
 
 ```bash
-python -m venv venv
+python -m venv venv --system-site-packages
 ```
 
 (this may take a few seconds to complete, and will produce no output).

--- a/gpio_watcher.py
+++ b/gpio_watcher.py
@@ -1,40 +1,36 @@
-
-
-import RPi.GPIO as GPIO
+from gpiozero import Button
+from signal import pause
 import time
 
-GPIO.setmode(GPIO.BOARD)
 
 class GPIOWatcher(object):
-    
+
     def __init__(self, headerNo, onChange=None, debounceSeconds=2):
         """
         headerNo - the physical pin number of the GPIO header
-        callback - a function called when a change is observed
-        debounceSeconds - don't fire a change event if one has been fired within this time
+        onChange - a function called when the button is pressed
+        debounceSeconds - don't fire a press event if one has been fired within this time
         """
-        self.headerNo = headerNo
         self.onChange = onChange
         self.debounceSeconds = debounceSeconds
         self.lastEventTime = 0
-        GPIO.setup(self.headerNo, GPIO.IN)
-        self.last_reported_state = self.read()
-    
-    def read(self):
-        """Return True if the GPIO header is positive, False if negative"""
-        return GPIO.input(self.headerNo) == 1
-    
-    def enter_loop(self, pollingIntervalSeconds = 0.1):
-        """Loop endlessly, firing onChange as states change"""
-        while True:
-            state = self.read()
-            if state != self.last_reported_state:
-                self.last_reported_state = state
-                timeNow = time.time()
-                if timeNow > self.lastEventTime + self.debounceSeconds:
+        self.button = Button("BOARD%d" % headerNo)
+        self.button.when_pressed = self._on_press
+
+    def _on_press(self):
+        timeNow = time.time()
+        if timeNow > self.lastEventTime + self.debounceSeconds:
+            self.lastEventTime = timeNow
+            if self.onChange:
+                try:
                     self.onChange()
-                    self.lastEventTime = timeNow
-            time.sleep(pollingIntervalSeconds)
+                except Exception as e:
+                    print(f"Error in onChange callback: {e}")
+
+    def enter_loop(self):
+        """Block forever, waiting for button presses"""
+        pause()
+
 
 if __name__ == "__main__":
     def printMessage():

--- a/main.py
+++ b/main.py
@@ -101,8 +101,4 @@ if __name__ == "__main__":
         goGoPaparazzo()
     else:
         watcher = GPIOWatcher(7, onChange=goGoPaparazzo, debounceSeconds=20)
-        while True:
-            try:
-                watcher.enter_loop()
-            except Exception as e:
-                print(f"Error: {e}")
+        watcher.enter_loop()

--- a/main.py
+++ b/main.py
@@ -15,8 +15,8 @@ except ImportError:
 
 try:
     from gpio_watcher import GPIOWatcher
-except Exception:
-    print("Import GPIOWatcher failed, the script will only work in test mode.")
+except Exception as e:
+    print(f"Import GPIOWatcher failed ({e}), the script will only work in test mode.")
     GPIOWatcher = None
 
 

--- a/main.py
+++ b/main.py
@@ -15,8 +15,9 @@ except ImportError:
 
 try:
     from gpio_watcher import GPIOWatcher
-except ImportError:
+except Exception:
     print("Import GPIOWatcher failed, the script will only work in test mode.")
+    GPIOWatcher = None
 
 
 def goGoPaparazzo():
@@ -100,5 +101,8 @@ if __name__ == "__main__":
     if "--test" in sys.argv:
         goGoPaparazzo()
     else:
+        if GPIOWatcher is None:
+            print("GPIO not available, cannot run in normal mode.")
+            exit(1)
         watcher = GPIOWatcher(7, onChange=goGoPaparazzo, debounceSeconds=20)
         watcher.enter_loop()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 gpiozero
-lgpio
 annotated-types==0.7.0
 anyio==4.12.1
 atproto==0.0.65

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,6 @@ pydantic==2.12.5
 pydantic_core==2.41.5
 requests==2.32.5
 requests-oauthlib==2.0.0
-RPi.GPIO==0.7.1
 tweepy==4.16.0
 typing-inspection==0.4.2
 typing_extensions==4.15.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+gpiozero
+lgpio
 annotated-types==0.7.0
 anyio==4.12.1
 atproto==0.0.65


### PR DESCRIPTION
The `rpi.gpio` package doesn't work on the Pi 5, so this PR moves the codebase to use `gpiozero` which ships with the operating system these days.  This should work on Pi 4 and 5.